### PR TITLE
Simplify tpagb calibration

### DIFF
--- a/tpagb_calibration/analysis/stats.py
+++ b/tpagb_calibration/analysis/stats.py
@@ -1,14 +1,16 @@
-#import sfh_tests_multi_proc
-import numpy as np
-import ResolvedStellarPops as rsp
-#import galaxy_tests
-import os
-#import tables
-import matplotlib.pylab as plt
-from TPAGBparams import snap_src
 import logging
+import os
+
+import numpy as np
+import matplotlib.pyplt as plt
+import ResolvedStellarPops as rsp
+
+from TPAGBparams import snap_src
+
 logger = logging.getLogger()
+
 angst_data = rsp.angst_tables.angst_table.AngstTables()
+
 def narratio_table(self):
     narratio_files = rsp.fileIO.get_files(self.outfile_dir, '*narratio*dat')
     stats.narratio_table(narratio_files)
@@ -433,6 +435,7 @@ def narratio_table(narratio_files, table_file='default'):
 
 
 def data_table(targets, table_file='default'):
+    """latex data table """
     # target, av, dist, [opt: frac comp, trgb, nrgb, nagb ratio] [ir: ..]
     if table_file == 'default':
         table_file = snap_src + '/tables/ancients_0.1_0.2_galaxies.dat'

--- a/tpagb_calibration/sfhs/vary_sfh.py
+++ b/tpagb_calibration/sfhs/vary_sfh.py
@@ -259,7 +259,7 @@ class VarySFHs(StarFormationHistories):
                 out_obj.add_params(res[i].result)
                 out_obj.write_params(outparam % i, loud=True)
 
-        os.system('ipcluster stop')
+        #os.system('ipcluster stop')
 
 
 def contamination_by_phases(sgal, srgb, sagb, filter2, diag_plot=False,


### PR DESCRIPTION
Only reason to go back to the old code is to re-run something from paper one. Not only that, but ready to branch again and try some more simplifications.
